### PR TITLE
Add quest import workflow

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -83,7 +83,13 @@
     },
     "QuestLog": {
       "Buttons": {
-        "AddQuest": "Add Quest"
+        "AddQuest": "Add Quest",
+        "ImportQuest": "Import Quests"
+      },
+      "Notifications": {
+        "ImportFailure": "No quests were imported. Please verify the JSON file.",
+        "ImportPartial": "Imported {success} quest(s); {fail} quest(s) could not be processed.",
+        "ImportSuccess": "Successfully imported {count} quest(s)."
       },
       "ContextMenu": {
         "CopyEntityLink": "Copy entity content link",

--- a/src/view/log/HandlerLog.js
+++ b/src/view/log/HandlerLog.js
@@ -1,6 +1,7 @@
 import {
    QuestDB,
    Socket,
+   Utils,
    ViewManager }     from '../../control/index.js';
 
 import { QuestAPI }  from '../../control/public/index.js';
@@ -8,6 +9,8 @@ import { QuestAPI }  from '../../control/public/index.js';
 import { Quest }     from '../../model/index.js';
 
 import { FQLDialog } from '../internal/index.js';
+
+import { questStatus } from '../../model/constants.js';
 
 /**
  * Provides all {@link JQuery} callbacks for the {@link QuestLog}.
@@ -34,6 +37,38 @@ export class HandlerLog
          const quest = await QuestDB.createQuest();
          ViewManager.questAdded({ quest });
       }
+   }
+
+   /**
+    * Opens a file chooser to import quest data from JSON files.
+    *
+    * @returns {Promise<void>}
+    */
+   static async questImport()
+   {
+      if (!game.user.isGM) { return; }
+
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.json';
+      input.multiple = true;
+      input.style.display = 'none';
+
+      const removeIfUnused = () =>
+      {
+         if (document.body.contains(input)) { input.remove(); }
+         document.body.removeEventListener('focus', removeIfUnused, true);
+      };
+
+      input.addEventListener('change', async (event) =>
+      {
+         document.body.removeEventListener('focus', removeIfUnused, true);
+         await HandlerLog.#handleImportInput(event);
+      }, { once: true });
+
+      document.body.appendChild(input);
+      document.body.addEventListener('focus', removeIfUnused, true);
+      input.click();
    }
 
    /**
@@ -95,5 +130,290 @@ export class HandlerLog
 
       const quest = QuestDB.getQuest(questId);
       if (quest) { await Socket.setQuestStatus({ quest, target }); }
+   }
+
+   /**
+    * Handles quest import data from the selected files.
+    *
+    * @param {Event} event - The change event from the file input.
+    *
+    * @returns {Promise<void>}
+    */
+   static async #handleImportInput(event)
+   {
+      const input = event.currentTarget;
+
+      if (!(input instanceof HTMLInputElement)) { return; }
+
+      const files = Array.from(input.files ?? []);
+      input.value = '';
+      input.remove();
+
+      if (!files.length) { return; }
+
+      let success = 0;
+      let fail = 0;
+
+      for (const file of files)
+      {
+         let parsed;
+
+         try
+         {
+            const text = await file.text();
+            parsed = JSON.parse(text);
+         }
+         catch (error)
+         {
+            console.error('ForienQuestLog | Failed to read quest import file.', error);
+            fail++;
+            continue;
+         }
+
+         const questPayloads = HandlerLog.#normalizeImportPayload(parsed);
+
+         if (!questPayloads.length)
+         {
+            fail++;
+            continue;
+         }
+
+         for (const questData of questPayloads)
+         {
+            const sanitized = HandlerLog.#sanitizeQuestData(questData);
+
+            if (!sanitized)
+            {
+               fail++;
+               continue;
+            }
+
+            try
+            {
+               await QuestDB.createQuest({ data: sanitized });
+               success++;
+            }
+            catch (error)
+            {
+               console.error('ForienQuestLog | Failed to create quest from import.', error);
+               fail++;
+            }
+         }
+      }
+
+      HandlerLog.#notifyImportOutcome({ success, fail });
+   }
+
+   /**
+    * Normalizes the JSON payload into an array of quest data objects.
+    *
+    * @param {unknown} payload - Raw JSON data.
+    *
+    * @returns {object[]} A normalized array of quest data objects.
+    */
+   static #normalizeImportPayload(payload)
+   {
+      if (Array.isArray(payload)) { return payload; }
+
+      if (payload && typeof payload === 'object')
+      {
+         if (Array.isArray(payload.quests)) { return payload.quests; }
+         if (Array.isArray(payload.data)) { return payload.data; }
+         return [payload];
+      }
+
+      return [];
+   }
+
+   /**
+    * Sanitizes quest data to match the expected schema.
+    *
+    * @param {unknown} data - The raw quest data.
+    *
+    * @returns {object|null} Sanitized quest data or null when invalid.
+    */
+   static #sanitizeQuestData(data)
+   {
+      if (!data || typeof data !== 'object') { return null; }
+
+      const questData = foundry.utils.duplicate(data);
+
+      const name = typeof questData.name === 'string' ? questData.name.trim() : '';
+      const status = typeof questData.status === 'string' && Object.values(questStatus).includes(questData.status) ?
+       questData.status : questStatus.inactive;
+
+      const sanitized = {
+         name: name.length > 0 ? name : game.i18n.localize('ForienQuestLog.API.QuestDB.Labels.NewQuest'),
+         status,
+         giver: typeof questData.giver === 'string' && questData.giver.trim().length > 0 ? questData.giver.trim() : null,
+         giverData: HandlerLog.#sanitizeGiverData(questData.giverData),
+         description: typeof questData.description === 'string' ? questData.description : '',
+         gmnotes: typeof questData.gmnotes === 'string' ? questData.gmnotes : '',
+         playernotes: typeof questData.playernotes === 'string' ? questData.playernotes : '',
+         image: typeof questData.image === 'string' ? questData.image : 'actor',
+         giverName: typeof questData.giverName === 'string' && questData.giverName.trim().length > 0 ?
+          questData.giverName.trim() : 'actor',
+         splash: typeof questData.splash === 'string' ? questData.splash : '',
+         splashPos: HandlerLog.#sanitizeSplashPos(questData.splashPos),
+         splashAsIcon: typeof questData.splashAsIcon === 'boolean' ? questData.splashAsIcon : false,
+         location: typeof questData.location === 'string' && questData.location.trim().length > 0 ?
+          questData.location.trim() : null,
+         priority: Number.isInteger(questData.priority) ? questData.priority : 0,
+         type: typeof questData.type === 'string' && questData.type.trim().length > 0 ? questData.type.trim() : null,
+         parent: null,
+         subquests: [],
+         tasks: HandlerLog.#sanitizeTasks(questData.tasks),
+         rewards: HandlerLog.#sanitizeRewards(questData.rewards)
+      };
+
+      const date = HandlerLog.#sanitizeDate(questData.date);
+      if (date) { sanitized.date = date; }
+
+      return sanitized;
+   }
+
+   /**
+    * Ensures splash position contains a valid value.
+    *
+    * @param {unknown} splashPos - Splash alignment.
+    *
+    * @returns {string} Sanitized splash alignment.
+    */
+   static #sanitizeSplashPos(splashPos)
+   {
+      const allowed = ['top', 'center', 'bottom'];
+      return typeof splashPos === 'string' && allowed.includes(splashPos) ? splashPos : 'center';
+   }
+
+   /**
+    * Sanitizes giver data.
+    *
+    * @param {unknown} giverData - Raw giver data.
+    *
+    * @returns {object|null} Sanitized giver data or null when invalid.
+    */
+   static #sanitizeGiverData(giverData)
+   {
+      if (!giverData || typeof giverData !== 'object') { return null; }
+
+      const data = foundry.utils.duplicate(giverData);
+
+      const name = typeof data.name === 'string' ? data.name : '';
+      const img = typeof data.img === 'string' ? data.img : '';
+      const uuid = typeof data.uuid === 'string' ? data.uuid : void 0;
+      const hasTokenImg = typeof data.hasTokenImg === 'boolean' ? data.hasTokenImg : false;
+
+      if (!uuid && !name && !img) { return null; }
+
+      return {
+         ...(uuid ? { uuid } : {}),
+         ...(name ? { name } : {}),
+         ...(img ? { img } : {}),
+         hasTokenImg
+      };
+   }
+
+   /**
+    * Sanitizes task data.
+    *
+    * @param {unknown} tasks - Raw tasks array.
+    *
+    * @returns {object[]} Sanitized task data entries.
+    */
+   static #sanitizeTasks(tasks)
+   {
+      if (!Array.isArray(tasks)) { return []; }
+
+      return tasks.reduce((acc, task) =>
+      {
+         if (!task || typeof task !== 'object') { return acc; }
+
+         const name = typeof task.name === 'string' ? task.name : '';
+
+         acc.push({
+            name,
+            completed: Boolean(task.completed),
+            failed: Boolean(task.failed),
+            hidden: Boolean(task.hidden),
+            uuidv4: Utils.uuidv4()
+         });
+
+         return acc;
+      }, []);
+   }
+
+   /**
+    * Sanitizes reward data.
+    *
+    * @param {unknown} rewards - Raw rewards array.
+    *
+    * @returns {object[]} Sanitized reward data entries.
+    */
+   static #sanitizeRewards(rewards)
+   {
+      if (!Array.isArray(rewards)) { return []; }
+
+      return rewards.reduce((acc, reward) =>
+      {
+         if (!reward || typeof reward !== 'object') { return acc; }
+
+         const type = typeof reward.type === 'string' ? reward.type : null;
+         const data = reward.data && typeof reward.data === 'object' ? foundry.utils.duplicate(reward.data) : {};
+
+         acc.push({
+            type,
+            data,
+            hidden: typeof reward.hidden === 'boolean' ? reward.hidden : false,
+            locked: typeof reward.locked === 'boolean' ? reward.locked : true,
+            uuidv4: Utils.uuidv4()
+         });
+
+         return acc;
+      }, []);
+   }
+
+   /**
+    * Sanitizes quest date metadata.
+    *
+    * @param {unknown} date - Raw date data.
+    *
+    * @returns {{create: number|null, start: number|null, end: number|null}|void} Sanitized quest date metadata.
+    */
+   static #sanitizeDate(date)
+   {
+      if (!date || typeof date !== 'object') { return void 0; }
+
+      const create = typeof date.create === 'number' ? date.create : null;
+      const start = typeof date.start === 'number' ? date.start : null;
+      const end = typeof date.end === 'number' ? date.end : null;
+
+      if (create === null && start === null && end === null) { return void 0; }
+
+      return { create, start, end };
+   }
+
+   /**
+    * Posts a notification summarizing the import result.
+    *
+    * @param {{success: number, fail: number}} result - Import summary.
+    */
+   static #notifyImportOutcome({ success, fail })
+   {
+      const total = success + fail;
+
+      if (success > 0 && fail === 0)
+      {
+         ViewManager.notifications.info(game.i18n.format('ForienQuestLog.QuestLog.Notifications.ImportSuccess',
+          { count: success }));
+      }
+      else if (success > 0 && fail > 0)
+      {
+         ViewManager.notifications.warn(game.i18n.format('ForienQuestLog.QuestLog.Notifications.ImportPartial',
+          { success, fail }));
+      }
+      else if (total > 0)
+      {
+         ViewManager.notifications.error(game.i18n.localize('ForienQuestLog.QuestLog.Notifications.ImportFailure'));
+      }
    }
 }

--- a/src/view/log/QuestLog.js
+++ b/src/view/log/QuestLog.js
@@ -126,6 +126,7 @@ export class QuestLog extends foundry.appv1.api.Application
       }
 
       html.on(jquery.click, '.new-quest-btn', HandlerLog.questAdd);
+      html.on(jquery.click, '.import-quest-btn', HandlerLog.questImport);
 
       html.on(jquery.click, '.actions.quest-status i.delete', HandlerLog.questDelete);
 

--- a/styles/quest-log.scss
+++ b/styles/quest-log.scss
@@ -86,6 +86,11 @@
         padding-bottom: 4px;
       }
 
+      .quest-actions {
+        display: flex;
+        gap: 8px;
+      }
+
       button {
         flex: 0 0 fit-content;
       }

--- a/templates/partials/quest-log/tab.html
+++ b/templates/partials/quest-log/tab.html
@@ -1,7 +1,12 @@
 <header>
   <h1 style="flex: 1;">{{fql_format 'ForienQuestLog.QuestLog.Labels.TableHeader' (localize (lookup questStatusI18n tab))}}</h1>
   {{#if (or isGM canCreate)}}
-    <button class="new-quest-btn"><i class="fas fa-plus"></i> {{localize 'ForienQuestLog.QuestLog.Buttons.AddQuest'}}</button>
+    <div class="quest-actions">
+      <button class="new-quest-btn"><i class="fas fa-plus"></i> {{localize 'ForienQuestLog.QuestLog.Buttons.AddQuest'}}</button>
+      {{#if isGM}}
+        <button class="import-quest-btn"><i class="fas fa-file-import"></i> {{localize 'ForienQuestLog.QuestLog.Buttons.ImportQuest'}}</button>
+      {{/if}}
+    </div>
   {{/if}}
 </header>
 <div class="table">


### PR DESCRIPTION
## Summary
- add a GM-only import button to the quest log UI with supporting styles and localization
- implement quest import handling that sanitizes JSON payloads before creating quests and reports success/failure

## Testing
- npm run eslint *(fails: existing lint errors in src/control/db/Enrich.js and src/view/internal/context-options.js)*

------
https://chatgpt.com/codex/tasks/task_e_68df9f51298c8327a0135b719107193f