### PR TITLE
Handle semicolon-separated quest categories

### DIFF
--- a/qa/manual/quest-categories-semicolon.md
+++ b/qa/manual/quest-categories-semicolon.md
@@ -1,0 +1,18 @@
+# Quest Categories Semicolon Separation
+
+## Goal
+Verify that quest categories separated by semicolons are treated as distinct categories.
+
+## Preconditions
+- Foundry VTT with the Forien Quest Log module installed and activated.
+- At least one quest exists (or create a test quest during the steps).
+
+## Steps
+1. Open the **Settings > Configure Settings** dialog in Foundry VTT.
+2. Switch to the **Module Settings** tab and locate **Forien Quest Log**.
+3. Set the **Quest Categories** value to `Main Quest;Side Quest` and save the configuration.
+4. Open the Forien Quest Log interface.
+
+## Expected Result
+- The category filter list contains two distinct categories: `Main Quest` and `Side Quest`.
+- Any quest assigned to one of the categories appears under the correct category header.

--- a/src/control/util/Utils.js
+++ b/src/control/util/Utils.js
@@ -350,7 +350,7 @@ export class Utils
          }
          else if (typeof entry === 'string')
          {
-            values.push(...entry.split(/[\n,]/));
+            values.push(...entry.split(/[\n,;]+/));
          }
          else if (entry && typeof entry === 'object')
          {
@@ -373,12 +373,12 @@ export class Utils
             }
             else
             {
-               values.push(...value.split(/[\n,]/));
+               values.push(...value.split(/[\n,;]+/));
             }
          }
          catch (_error)
          {
-            values.push(...value.split(/[\n,]/));
+            values.push(...value.split(/[\n,;]+/));
          }
       }
       else if (value && typeof value === 'object')


### PR DESCRIPTION
## Summary
- allow quest category normalization to split on semicolons
- document manual verification steps for semicolon-separated categories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690140e82c188327855bbfa7599a490d