### PR TITLE
Generalize quest grouping and render grouped categories across all tabs

### DIFF
--- a/src/view/log/QuestLog.js
+++ b/src/view/log/QuestLog.js
@@ -207,7 +207,11 @@ export class QuestLog extends foundry.appv1.api.Application
       const quests = QuestDB.sortCollect();
       const questCategories = Utils.getQuestCategories();
 
-      const groupedActive = QuestLog.#groupActiveQuests(quests.active, questCategories);
+      const groupedAvailable = QuestLog.#groupQuestsByCategory(quests.available, questCategories);
+      const groupedActive = QuestLog.#groupQuestsByCategory(quests.active, questCategories);
+      const groupedCompleted = QuestLog.#groupQuestsByCategory(quests.completed, questCategories);
+      const groupedFailed = QuestLog.#groupQuestsByCategory(quests.failed, questCategories);
+      const groupedInactive = QuestLog.#groupQuestsByCategory(quests.inactive, questCategories);
 
       return foundry.utils.mergeObject(super.getData(), {
          options,
@@ -220,20 +224,24 @@ export class QuestLog extends foundry.appv1.api.Application
          style: game.settings.get(constants.moduleName, settings.navStyle),
          questStatusI18n,
          quests,
-         groupedActive
+         groupedAvailable,
+         groupedActive,
+         groupedCompleted,
+         groupedFailed,
+         groupedInactive
       });
    }
 
    /**
-    * Groups active quests by category preserving configured category order.
+    * Groups quests by category preserving configured category order.
     *
-    * @param {Collection<QuestEntry>|undefined} collection - Active quest collection.
+    * @param {Collection<QuestEntry>|undefined} collection - Quest collection to group.
     *
     * @param {string[]} configuredCategories - Categories configured in module settings.
     *
     * @returns {{key: string, label: string, quests: QuestEntry[]}[]} Grouped quests ready for rendering.
     */
-   static #groupActiveQuests(collection, configuredCategories = [])
+   static #groupQuestsByCategory(collection, configuredCategories = [])
    {
       const groups = [];
       const groupMap = new Map();

--- a/templates/partials/quest-log/tab.html
+++ b/templates/partials/quest-log/tab.html
@@ -40,7 +40,7 @@
     {{/with}}
   {{/inline}}
 
-  {{#if (and groupedQuests (eq tab 'active'))}}
+  {{#if groupedQuests}}
     {{#each groupedQuests}}
       <h2 class="quest-category-heading">{{label}}</h2>
       <ul>

--- a/templates/quest-log.html
+++ b/templates/quest-log.html
@@ -10,20 +10,20 @@
   </nav>
   <section class="log-body {{style}}">
     <div class="tab available" data-group="primary" data-tab="available">
-      {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="available" quests=quests.available}}
+      {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="available" quests=quests.available groupedQuests=groupedAvailable}}
     </div>
     <div class="tab active" data-group="primary" data-tab="active">
       {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="active" quests=quests.active groupedQuests=groupedActive}}
     </div>
     <div class="tab completed" data-group="primary" data-tab="completed">
-      {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="completed" quests=quests.completed}}
+      {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="completed" quests=quests.completed groupedQuests=groupedCompleted}}
     </div>
     <div class="tab failed" data-group="primary" data-tab="failed">
-      {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="failed" quests=quests.failed}}
+      {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="failed" quests=quests.failed groupedQuests=groupedFailed}}
     </div>
     {{#if (or isGM isTrustedPlayerEdit)}}
       <div class="tab inactive" data-group="primary" data-tab="inactive">
-        {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="inactive" quests=quests.inactive}}
+        {{> "modules/forien-quest-log/templates/partials/quest-log/tab.html" tab="inactive" quests=quests.inactive groupedQuests=groupedInactive}}
       </div>
     {{/if}}
   </section>


### PR DESCRIPTION
### Motivation
- Make quest category grouping reusable for all status lists instead of only the `active` tab so categories appear consistently across the UI.
- Pass grouped data into templates so each tab can render quests grouped by category when applicable.

### Description
- Introduced a generalized private helper `#groupQuestsByCategory` (replacing the prior `#groupActiveQuests` concept) to group any quest collection by configured categories and preserve the configured order.
- In `getData` the grouped collections `groupedAvailable`, `groupedActive`, `groupedCompleted`, `groupedFailed`, and `groupedInactive` are produced via `#groupQuestsByCategory` and returned to the template data.
- Updated `templates/quest-log.html` to pass the corresponding `grouped*` property into the tab partial for each tab.
- Modified `templates/partials/quest-log/tab.html` to render categories whenever `groupedQuests` is present (changed the conditional from only `active` to any tab with grouped data), and retained the fallback `ForienQuestLog.QuestLog.Labels.NoCategory` label for uncategorized quests.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696916442c1083278fa220be0d81ac60)